### PR TITLE
Use ES module syntax. Allow multiple helpers per file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ In `metalsmith.json`:
 Using Metalsmith's API:
 
 ```js
-var discoverHelpers = require('metalsmith-discover-helpers')
+import Metalsmith from "metalsmith";
+import discoverHelpers from "metalsmith-discover-helpers";
 
-require('metalsmith')(__dirname)
+Metalsmith(__dirname)
   .use(discoverHelpers({
     directory: 'helpers',
     pattern: /\.js$/

--- a/package.json
+++ b/package.json
@@ -30,5 +30,6 @@
   "bugs": {
     "url": "https://github.com/timdp/metalsmith-discover-helpers/issues"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "type": "module"
 }


### PR DESCRIPTION
Update to use ES module syntax.
Also allows multiple helpers in a file based on their exported function names. The "default" export becomes a helper named after the filename it exists inside.